### PR TITLE
CI: Undo build on pull request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Gatsby Publish
 on:
   push:
     branches: [gatsby]
-  pull_request:
-    branches: [gatsby]
 
 jobs:
   build:


### PR DESCRIPTION
Website should not be pushed to production when a PR is made. Only when being pushed to master.

In the future, it may even make more sense to only push to production when a version is built. But for now, this should be fine.