### PR TITLE
CI: Update for new branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,18 +2,18 @@ name: Test
 
 on:
   push:
-    branches: [app, dev, gatsby]
+    branches: [gatsby, develop]
   pull_request:
-    branches: [app, dev, gatsby]
+    branches: [gatsby, develop]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-    - run: npm install
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test


### PR DESCRIPTION
Old branches were recently deleted. Will now use develop branch for development and treat gatsby branch as master branch. The master branch name must be reserved in order to properly work with GitHub Pages.